### PR TITLE
remove deps via adapters

### DIFF
--- a/src/adapters/base-tool-adapter.ts
+++ b/src/adapters/base-tool-adapter.ts
@@ -1,0 +1,19 @@
+import * as path from "path"
+import { AdapterTextDocument } from "./interfaces"
+
+export interface BaseAdapter {
+	showTextDocument(filePath: string, options?: { preview: boolean }): Promise<void>
+	executeCommand(command: string, ...args: any[]): Promise<void>
+	showDiffView(originalUri: string, modifiedUri: string, title: string, options?: { preview: boolean }): Promise<void>
+	closeDiffViews(): Promise<void>
+	getWorkspaceTextDocuments(): AdapterTextDocument[]
+
+	// File operations
+	pathUtil(): typeof path
+	readFile(path: string, encoding: string): Promise<string>
+	writeFile(path: string, data: string, options?: { encoding?: string; flag?: string }): Promise<void>
+	access(path: string): Promise<boolean>
+	mkdir(path: string, options: { recursive: boolean }): Promise<void>
+	rmdir(path: string, options: { recursive: boolean; force: boolean }): Promise<void>
+	createTempDir(path: string): Promise<string>
+}

--- a/src/adapters/base-tool-adapter.ts
+++ b/src/adapters/base-tool-adapter.ts
@@ -4,7 +4,7 @@ import { AdapterTextDocument } from "./interfaces"
 export interface BaseAdapter {
 	showTextDocument(filePath: string, options?: { preview: boolean }): Promise<void>
 	executeCommand(command: string, ...args: any[]): Promise<void>
-	showDiffView(originalUri: string, modifiedUri: string, title: string, options?: { preview: boolean }): Promise<void>
+	showDiffView(originalUri: string, originalContent: string, tempFilePath: string, title: string): Promise<void>
 	closeDiffViews(): Promise<void>
 	getWorkspaceTextDocuments(): AdapterTextDocument[]
 

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -1,0 +1,2 @@
+export * from "./base-tool-adapter"
+export * from "./vs-code-tool-adapter"

--- a/src/adapters/interfaces/index.ts
+++ b/src/adapters/interfaces/index.ts
@@ -1,0 +1,5 @@
+export interface AdapterTextDocument {
+	uri: { fsPath: string }
+	isDirty: boolean
+	save: () => PromiseLike<boolean>
+}

--- a/src/adapters/vs-code-tool-adapter.ts
+++ b/src/adapters/vs-code-tool-adapter.ts
@@ -1,0 +1,99 @@
+import * as vscode from "vscode"
+import * as path from "path"
+import * as os from "os"
+import { BaseAdapter } from "./base-tool-adapter"
+import { AdapterTextDocument } from "./interfaces"
+
+export class VSCodeAdapter implements BaseAdapter {
+	async showTextDocument(filePath: string, options?: { preview: boolean }): Promise<void> {
+		await vscode.window.showTextDocument(vscode.Uri.file(filePath), options)
+	}
+
+	async executeCommand(command: string, ...args: any[]): Promise<void> {
+		await vscode.commands.executeCommand(command, ...args)
+	}
+
+	async showDiffView(
+		originalUri: string,
+		modifiedUri: string,
+		title: string,
+		options?: { preview: boolean }
+	): Promise<void> {
+		await vscode.commands.executeCommand(
+			"vscode.diff",
+			vscode.Uri.parse(originalUri),
+			vscode.Uri.file(modifiedUri),
+			title,
+			options
+		)
+	}
+
+	async closeDiffViews(): Promise<void> {
+		const tabs = vscode.window.tabGroups.all
+			.map((tg) => tg.tabs)
+			.flat()
+			.filter((tab) => tab.input instanceof vscode.TabInputTextDiff && tab.input?.modified?.scheme === "kodu")
+
+		for (const tab of tabs) {
+			await vscode.window.tabGroups.close(tab)
+		}
+	}
+
+	getWorkspaceTextDocuments(): AdapterTextDocument[] {
+		return vscode.workspace.textDocuments.map((doc) => ({
+			uri: { fsPath: doc.uri.fsPath },
+			isDirty: doc.isDirty,
+			save: () => doc.save(),
+		}))
+	}
+
+	// File operations using vscode.workspace.fs
+	async readFile(path: string, encoding: string): Promise<string> {
+		const uri = vscode.Uri.file(path)
+		const uint8Array = await vscode.workspace.fs.readFile(uri)
+		const decoder = new TextDecoder(encoding)
+		return decoder.decode(uint8Array)
+	}
+
+	async writeFile(path: string, data: string, options?: { encoding?: string; flag?: string }): Promise<void> {
+		const uri = vscode.Uri.file(path)
+		const encoder = new TextEncoder()
+		const uint8Array = encoder.encode(data)
+		await vscode.workspace.fs.writeFile(uri, uint8Array)
+	}
+
+	async access(path: string): Promise<boolean> {
+		const uri = vscode.Uri.file(path)
+		try {
+			await vscode.workspace.fs.stat(uri)
+			return true
+		} catch {
+			return false
+		}
+	}
+
+	async mkdir(path: string, options: { recursive: boolean }): Promise<void> {
+		const uri = vscode.Uri.file(path)
+		await vscode.workspace.fs.createDirectory(uri)
+	}
+
+	async rmdir(path: string, options: { recursive: boolean; force: boolean }): Promise<void> {
+		const uri = vscode.Uri.file(path)
+		await vscode.workspace.fs.delete(uri, { recursive: options.recursive, useTrash: !options.force })
+	}
+
+	async createTempDir(path: string): Promise<string> {
+		const tempPath = this.createPath(os.tmpdir(), path)
+		await this.mkdir(tempPath, { recursive: true })
+
+		return tempPath
+	}
+
+	createPath(directory: string, filePath: string): string {
+		return path.join(directory, filePath)
+	}
+
+	pathUtil(): typeof path {
+		return path
+	}
+}

--- a/src/adapters/vs-code-tool-adapter.ts
+++ b/src/adapters/vs-code-tool-adapter.ts
@@ -15,16 +15,17 @@ export class VSCodeAdapter implements BaseAdapter {
 
 	async showDiffView(
 		originalUri: string,
-		modifiedUri: string,
-		title: string,
-		options?: { preview: boolean }
+		originalContent: string,
+		tempFilePath: string,
+		title: string
 	): Promise<void> {
 		await vscode.commands.executeCommand(
 			"vscode.diff",
-			vscode.Uri.parse(originalUri),
-			vscode.Uri.file(modifiedUri),
-			title,
-			options
+			vscode.Uri.parse(originalUri).with({
+				query: Buffer.from(originalContent).toString("base64"),
+			}),
+			vscode.Uri.file(tempFilePath),
+			title
 		)
 	}
 

--- a/src/agent/v1/index.ts
+++ b/src/agent/v1/index.ts
@@ -12,6 +12,7 @@ import { AskResponse, TaskExecutor } from "./task-executor"
 import { findLastIndex } from "../../utils"
 import { amplitudeTracker } from "../../utils/amplitude"
 import { ToolInput } from "./tools/types"
+import { VSCodeAdapter } from "../../adapters/"
 
 // new KoduDev
 export class KoduDev {
@@ -21,13 +22,17 @@ export class KoduDev {
 	public taskExecutor: TaskExecutor
 	private providerRef: WeakRef<ClaudeDevProvider>
 	private pendingAskResponse: ((value: AskResponse) => void) | null = null
+	private adapter: VSCodeAdapter
 
 	constructor(options: KoduDevOptions) {
 		const { provider, apiConfiguration, customInstructions, task, images, historyItem } = options
 		this.stateManager = new StateManager(options)
 		this.providerRef = new WeakRef(provider)
 		this.apiManager = new ApiManager(provider, apiConfiguration, customInstructions)
+		this.adapter = new VSCodeAdapter()
+
 		this.toolExecutor = new ToolExecutor({
+			adapter: this.adapter,
 			cwd: getCwd(),
 			alwaysAllowReadOnly: this.stateManager.alwaysAllowReadOnly,
 			alwaysAllowWriteOnly: this.stateManager.alwaysAllowWriteOnly,

--- a/src/agent/v1/tool-executor.ts
+++ b/src/agent/v1/tool-executor.ts
@@ -12,6 +12,7 @@ import {
 	ReadFileTool,
 	WriteFileTool,
 } from "./tools"
+import { BaseAdapter } from "../../adapters/base-tool-adapter"
 
 export class ToolExecutor {
 	private runningProcessId: number | undefined
@@ -19,8 +20,10 @@ export class ToolExecutor {
 	private alwaysAllowReadOnly: boolean
 	private alwaysAllowWriteOnly: boolean
 	private koduDev: KoduDev
+	private adapter: BaseAdapter
 
 	constructor(options: AgentToolOptions) {
+		this.adapter = options.adapter
 		this.cwd = options.cwd
 		this.alwaysAllowReadOnly = options.alwaysAllowReadOnly
 		this.alwaysAllowWriteOnly = options.alwaysAllowWriteOnly
@@ -29,6 +32,7 @@ export class ToolExecutor {
 
 	private get options(): AgentToolOptions {
 		return {
+			adapter: this.adapter,
 			cwd: this.cwd,
 			alwaysAllowReadOnly: this.alwaysAllowReadOnly,
 			alwaysAllowWriteOnly: this.alwaysAllowWriteOnly,

--- a/src/agent/v1/tools/base-agent.tool.ts
+++ b/src/agent/v1/tools/base-agent.tool.ts
@@ -1,4 +1,5 @@
 import { KoduDev } from ".."
+import { BaseAdapter } from "../../../adapters/base-tool-adapter"
 import { ToolResponse } from "../types"
 import { AgentToolOptions, AgentToolParams } from "./types"
 
@@ -8,10 +9,12 @@ export abstract class BaseAgentTool {
 	protected alwaysAllowWriteOnly: boolean
 	protected koduDev: KoduDev
 	protected setRunningProcessId: (pid: number | undefined) => void
+	protected adapter: BaseAdapter
 
 	protected abstract params: AgentToolParams
 
 	constructor(options: AgentToolOptions) {
+		this.adapter = options.adapter
 		this.cwd = options.cwd
 		this.alwaysAllowReadOnly = options.alwaysAllowReadOnly
 		this.alwaysAllowWriteOnly = options.alwaysAllowWriteOnly
@@ -23,6 +26,7 @@ export abstract class BaseAgentTool {
 
 	protected get options(): AgentToolOptions {
 		return {
+			adapter: this.adapter,
 			cwd: this.cwd,
 			alwaysAllowReadOnly: this.alwaysAllowReadOnly,
 			alwaysAllowWriteOnly: this.alwaysAllowWriteOnly,

--- a/src/agent/v1/tools/list-code-definition-names.tool.ts
+++ b/src/agent/v1/tools/list-code-definition-names.tool.ts
@@ -1,4 +1,3 @@
-import * as path from "path"
 import { serializeError } from "serialize-error"
 
 import { parseSourceCodeForDefinitionsTopLevel } from "../../../parse-source-code"
@@ -36,7 +35,7 @@ export class ListCodeDefinitionNamesTool extends BaseAgentTool {
 		}
 
 		try {
-			const absolutePath = path.resolve(this.cwd, relDirPath)
+			const absolutePath = this.adapter.pathUtil().resolve(this.cwd, relDirPath)
 			const result = await parseSourceCodeForDefinitionsTopLevel(absolutePath)
 
 			const message = JSON.stringify({

--- a/src/agent/v1/tools/list-files.tool.ts
+++ b/src/agent/v1/tools/list-files.tool.ts
@@ -1,4 +1,3 @@
-import * as path from "path"
 import { serializeError } from "serialize-error"
 import { LIST_FILES_LIMIT, listFiles } from "../../../parse-source-code"
 import { ClaudeAsk, ClaudeSay, ClaudeSayTool } from "../../../shared/ExtensionMessage"
@@ -36,7 +35,7 @@ export class ListFilesTool extends BaseAgentTool {
 
 		try {
 			const recursive = recursiveRaw?.toLowerCase() === "true"
-			const absolutePath = path.resolve(this.cwd, relDirPath)
+			const absolutePath = this.adapter.pathUtil().resolve(this.cwd, relDirPath)
 			const files = await listFiles(absolutePath, recursive)
 			const result = this.formatFilesList(absolutePath, files)
 
@@ -96,7 +95,7 @@ export class ListFilesTool extends BaseAgentTool {
 			`
 		}
 		try {
-			const absolutePath = path.resolve(this.cwd, relDirPath)
+			const absolutePath = this.adapter.pathUtil().resolve(this.cwd, relDirPath)
 			const files = await listFiles(absolutePath, false)
 			const result = this.formatFilesList(absolutePath, files)
 
@@ -156,7 +155,7 @@ export class ListFilesTool extends BaseAgentTool {
 		}
 
 		try {
-			const absolutePath = path.resolve(this.cwd, relDirPath)
+			const absolutePath = this.adapter.pathUtil().resolve(this.cwd, relDirPath)
 			const files = await listFiles(absolutePath, true)
 			const result = this.formatFilesList(absolutePath, files)
 
@@ -197,7 +196,7 @@ export class ListFilesTool extends BaseAgentTool {
 		const sorted = files
 			.map((file) => {
 				// convert absolute path to relative path
-				const relativePath = path.relative(absolutePath, file)
+				const relativePath = this.adapter.pathUtil().relative(absolutePath, file)
 				return file.endsWith("/") ? relativePath + "/" : relativePath
 			})
 			// Sort so files are listed under their respective directories to make it clear what files are children of what directories. Since we build file list top down, even if file list is truncated it will show directories that claude can then explore further.

--- a/src/agent/v1/tools/read-file.tool.ts
+++ b/src/agent/v1/tools/read-file.tool.ts
@@ -1,4 +1,3 @@
-import * as path from "path"
 import { serializeError } from "serialize-error"
 
 import { ToolResponse } from "../types"
@@ -34,7 +33,7 @@ export class ReadFileTool extends BaseAgentTool {
 			`
 		}
 		try {
-			const absolutePath = path.resolve(this.cwd, relPath)
+			const absolutePath = this.adapter.pathUtil().resolve(this.cwd, relPath)
 			const content = await extractTextFromFile(absolutePath)
 
 			const message = JSON.stringify({

--- a/src/agent/v1/tools/search-files.tool.ts
+++ b/src/agent/v1/tools/search-files.tool.ts
@@ -1,4 +1,3 @@
-import * as path from "path"
 import { serializeError } from "serialize-error"
 import { ClaudeSayTool } from "../../../shared/ExtensionMessage"
 import { ToolResponse } from "../types"
@@ -53,7 +52,7 @@ export class SearchFilesTool extends BaseAgentTool {
 		}
 
 		try {
-			const absolutePath = path.resolve(this.cwd, relDirPath)
+			const absolutePath = this.adapter.pathUtil().resolve(this.cwd, relDirPath)
 			const results = await regexSearchFiles(this.cwd, absolutePath, regex, filePattern)
 
 			const message = JSON.stringify({

--- a/src/agent/v1/tools/types/index.ts
+++ b/src/agent/v1/tools/types/index.ts
@@ -2,6 +2,7 @@ import { ClaudeAsk, ClaudeSay } from "../../../../shared/ExtensionMessage"
 import { ToolName } from "../../../../shared/Tool"
 import { ClaudeAskResponse } from "../../../../shared/WebviewMessage"
 import { KoduDev } from "../.."
+import { BaseAdapter } from "../../../../adapters"
 
 export type ToolInput = {
 	path?: string
@@ -27,6 +28,7 @@ export type AgentToolParams = {
 }
 
 export type AgentToolOptions = {
+	adapter: BaseAdapter
 	cwd: string
 	alwaysAllowReadOnly: boolean
 	alwaysAllowWriteOnly: boolean

--- a/src/agent/v1/tools/write-file.tool.ts
+++ b/src/agent/v1/tools/write-file.tool.ts
@@ -147,9 +147,9 @@ export class WriteFileTool extends BaseAgentTool {
 		const tempFilePath = path.join(tempDir, path.basename(absolutePath))
 		await this.adapter.writeFile(tempFilePath, newContent)
 
-		await this.adapter.executeCommand(
-			"vscode.diff",
+		await this.adapter.showDiffView(
 			`claude-dev-diff:${path.basename(absolutePath)}`,
+			originalContent,
 			tempFilePath,
 			`${path.basename(absolutePath)}: ${fileExists ? "Original ↔ Claude's Changes" : "New File"} (Editable)`
 		)


### PR DESCRIPTION
## What
remove VS Code dependencies via refactoring to an adapter.

However, its not completely independent right now, because of a lot of utils being used.