### PR TITLE
Feat/local fetch

### DIFF
--- a/extension/src/agent/v1/tools/runners/web-search-tool.ts
+++ b/extension/src/agent/v1/tools/runners/web-search-tool.ts
@@ -16,7 +16,7 @@ export class WebSearchTool extends BaseAgentTool {
 		const { say, updateAsk, input } = this.params
 		const { searchQuery, baseLink } = input
 
-		if (!searchQuery || !baseLink) {
+		if (!searchQuery) {
 			await say('error', 'Claude tried to use `web_search` without required parameters. Retrying...')
 			return `Error: Missing value for required parameters. Please retry with complete response.
 				A good example of a web_search tool call is:
@@ -28,7 +28,7 @@ export class WebSearchTool extends BaseAgentTool {
 				Please try again with the correct parameters.`
 		}
 
-		const confirmation = await this.askToolExecConfirmation(searchQuery, baseLink)
+		const confirmation = await this.askToolExecConfirmation(searchQuery, baseLink || '')
 		if (confirmation.response !== 'yesButtonTapped') {
 			await updateAsk(
 				'tool',

--- a/extension/webview-ui-vite/src/components/ChatRow/ToolRenderV1.tsx
+++ b/extension/webview-ui-vite/src/components/ChatRow/ToolRenderV1.tsx
@@ -606,12 +606,13 @@ export const WebSearchBlock: React.FC<WebSearchTool & ToolAddons> = ({
 		approvalState={approvalState}
 		onApprove={onApprove}
 		onReject={onReject}>
-		<p className="text-xs">
-			<span className="font-semibold">Search for:</span> {searchQuery}
-		</p>
-		{baseLink && (
+		{baseLink ? (
 			<p className="text-xs">
-				<span className="font-semibold">Starting from:</span> {baseLink}
+				<span className="font-semibold">Accessing:</span> {baseLink}
+			</p>
+		) : (
+			<p className="text-xs">
+				<span className="font-semibold">Search for:</span> {searchQuery}
 			</p>
 		)}
 	</ToolBlock>
@@ -758,3 +759,4 @@ export const ToolContentBlock: React.FC<{
 			return null
 	}
 }
+


### PR DESCRIPTION
## Feature
Fetch the content of a page using pupetteer 
## Improvement ideas/areas
- By default it could use our own backend for web search (upsell it because it's expensive)
- Make a toggle to use our own backend for websearch of our own web search (that will cost more) ? 
- Change the system prompt to use the tool more often. I have almost never seen it used before 

## Prompts to try 
### Web search
`Use web_search tool in order to see the meaning of the word "discombolulated" in french.`
### Fetch page
`Use web_search tool in order to see the meaning of the word "discombolulated" in french. use the baseLink of "https://context.reverso.net/translation/english-french/discombobulated"`

