### PR TITLE
chore: enabled model selection in url search tool

### DIFF
--- a/extension/src/agent/v1/prompts/base-system.ts
+++ b/extension/src/agent/v1/prompts/base-system.ts
@@ -194,10 +194,11 @@ Usage:
 </ask_consultant>
 
 ## web_search
-Description: Request to perform a web search for the specified query. This tool searches the web for information related to the query and provides relevant results that can help you gain insights, find solutions, or explore new ideas related to the task at hand.
+Description: Request to perform a web search for the specified query. This tool searches the web for information related to the query and provides relevant results that can help you gain insights, find solutions, or explore new ideas related to the task at hand. Since this tool uses an LLM to understand the web results, you can also specify which model to use with the browser using the 'browserModel' parameter.
 Parameters:
 - searchQuery: (required) The query to search the web for. This should be a clear and concise search query.
 - baseLink: (optional) The base link to use for the search. If provided, the search will be performed using the specified base link.
+- browserModel: (optional) The browser model to use for the search. Use 'smart' for slower but smarter, deeper search, use 'fast' for faster but less smart search or with things which are readily available on the web.
 Usage:
 <web_search>
 <searchQuery>Your search query here</searchQuery>

--- a/extension/src/agent/v1/tools/runners/web-search-tool.ts
+++ b/extension/src/agent/v1/tools/runners/web-search-tool.ts
@@ -14,7 +14,7 @@ export class WebSearchTool extends BaseAgentTool {
 
 	async execute(): Promise<ToolResponse> {
 		const { say, ask, updateAsk, input } = this.params
-		const { searchQuery, baseLink } = input
+		const { searchQuery, baseLink, browserModel = "fast" } = input
 
 		if (!searchQuery) {
 			await say("error", "Claude tried to use `web_search` without required parameter `searchQuery`. Retrying...")
@@ -36,6 +36,7 @@ export class WebSearchTool extends BaseAgentTool {
 					tool: "web_search",
 					searchQuery,
 					baseLink,
+					browserModel,
 					approvalState: "pending",
 					ts: this.ts,
 				},
@@ -51,6 +52,7 @@ export class WebSearchTool extends BaseAgentTool {
 						tool: "web_search",
 						searchQuery,
 						baseLink,
+						browserModel,
 						approvalState: "rejected",
 						ts: this.ts,
 						userFeedback: text,
@@ -73,6 +75,7 @@ export class WebSearchTool extends BaseAgentTool {
 						tool: "web_search",
 						searchQuery,
 						baseLink,
+						browserModel,
 						approvalState: "loading",
 						ts: this.ts,
 					},
@@ -83,7 +86,7 @@ export class WebSearchTool extends BaseAgentTool {
 			const result = this.koduDev
 				.getApiManager()
 				.getApi()
-				?.sendWebSearchRequest?.(searchQuery, baseLink, this.abortController.signal)
+				?.sendWebSearchRequest?.(searchQuery, baseLink, browserModel, this.abortController.signal)
 
 			if (!result) {
 				throw new Error("Unable to read response")
@@ -103,6 +106,7 @@ export class WebSearchTool extends BaseAgentTool {
 								tool: "web_search",
 								searchQuery,
 								baseLink,
+								browserModel,
 								content: chunk.content,
 								streamType: chunk.type,
 								approvalState: "loading",
@@ -121,6 +125,7 @@ export class WebSearchTool extends BaseAgentTool {
 							tool: {
 								tool: "web_search",
 								searchQuery,
+								browserModel,
 								baseLink,
 								approvalState: "error",
 								error: "Web search was aborted",
@@ -141,6 +146,7 @@ export class WebSearchTool extends BaseAgentTool {
 						tool: "web_search",
 						searchQuery,
 						baseLink,
+						browserModel,
 						approvalState: "approved",
 						ts: this.ts,
 					},
@@ -155,6 +161,7 @@ export class WebSearchTool extends BaseAgentTool {
 				{
 					tool: {
 						tool: "web_search",
+						browserModel,
 						searchQuery: searchQuery ?? "",
 						baseLink: baseLink ?? "",
 						approvalState: "error",

--- a/extension/src/agent/v1/tools/schema/web_search.ts
+++ b/extension/src/agent/v1/tools/schema/web_search.ts
@@ -35,20 +35,34 @@ const schema = z.object({
 		.string()
 		.optional()
 		.describe("The base link provided by the user. If it is provided, you can start your search from here."),
+	browserModel: z
+		.enum(["smart", "fast"])
+		.default("fast")
+		.optional()
+		.describe(
+			"The browser model to use for the search. Use 'smart' for slower but smarter search, use 'fast' for faster but less smart search."
+		),
 })
 
 const examples = [
 	`<tool name="web_search">
   <searchQuery>Latest advancements in AI technology</searchQuery>
+  <browserModel>smart</browserModel>
 </tool>`,
 
 	`<tool name="web_search">
   <searchQuery>How to optimize React applications?</searchQuery>
   <baseLink>https://reactjs.org/docs/optimizing-performance.html</baseLink>
+  <browserModel>smart</browserModel>
 </tool>`,
 
 	`<tool name="web_search">
   <searchQuery>Best practices for REST API design</searchQuery>
+</tool>`,
+
+	`<tool name="web_search">
+  <searchQuery>Fixing type error in my code</searchQuery>
+  <browserModel>fast</browserModel>
 </tool>`,
 ]
 

--- a/extension/src/agent/v1/tools/types/index.ts
+++ b/extension/src/agent/v1/tools/types/index.ts
@@ -27,6 +27,7 @@ export type ToolInput = {
 	searchQuery?: string
 	query?: string
 	baseLink?: string
+	browserModel?: "smart" | "fast"
 	url?: string
 }
 

--- a/extension/src/api/index.ts
+++ b/extension/src/api/index.ts
@@ -49,6 +49,7 @@ export interface ApiHandler {
 	sendWebSearchRequest?(
 		searchQuery: string,
 		baseLink?: string,
+		browserModel?: string,
 		abortSignal?: AbortSignal
 	): AsyncIterable<WebSearchResponseDto>
 

--- a/extension/src/api/kodu.ts
+++ b/extension/src/api/kodu.ts
@@ -413,6 +413,7 @@ export class KoduHandler implements ApiHandler {
 	async *sendWebSearchRequest(
 		searchQuery: string,
 		baseLink?: string,
+		browserModel?: string,
 		abortSignal?: AbortSignal
 	): AsyncIterable<WebSearchResponseDto> {
 		const response = await axios.post(
@@ -420,6 +421,7 @@ export class KoduHandler implements ApiHandler {
 			{
 				searchQuery,
 				baseLink,
+				browserModel,
 			},
 			{
 				headers: {

--- a/extension/src/shared/kodu.ts
+++ b/extension/src/shared/kodu.ts
@@ -1,7 +1,7 @@
 import Anthropic from "@anthropic-ai/sdk"
 
-// const KODU_BASE_URL = "http://localhost:3000"
-const KODU_BASE_URL = "https://www.kodu.ai"
+const KODU_BASE_URL = "http://localhost:3000"
+// const KODU_BASE_URL = "https://www.kodu.ai"
 
 export function getKoduSignInUrl(uriScheme?: string, extensionName?: string) {
 	return `${KODU_BASE_URL}/auth/login?redirectTo=${uriScheme}://kodu-ai.${extensionName}&ext=1`

--- a/extension/src/shared/kodu.ts
+++ b/extension/src/shared/kodu.ts
@@ -1,7 +1,7 @@
 import Anthropic from "@anthropic-ai/sdk"
 
-const KODU_BASE_URL = "http://localhost:3000"
-// const KODU_BASE_URL = "https://www.kodu.ai"
+// const KODU_BASE_URL = "http://localhost:3000"
+const KODU_BASE_URL = "https://www.kodu.ai"
 
 export function getKoduSignInUrl(uriScheme?: string, extensionName?: string) {
 	return `${KODU_BASE_URL}/auth/login?redirectTo=${uriScheme}://kodu-ai.${extensionName}&ext=1`

--- a/extension/src/shared/new-tools.ts
+++ b/extension/src/shared/new-tools.ts
@@ -69,6 +69,7 @@ export interface WebSearchTool {
 	searchQuery: string
 	baseLink?: string
 	content?: string
+	browserModel?: "smart" | "fast"
 	streamType?: "start" | "explore" | "summarize" | "end"
 }
 

--- a/extension/webview-ui-vite/src/components/ChatRow/Tools/WebSearchTool.tsx
+++ b/extension/webview-ui-vite/src/components/ChatRow/Tools/WebSearchTool.tsx
@@ -26,6 +26,7 @@ type EnhancedWebSearchBlockProps = WebSearchTool & ToolAddons
 export const EnhancedWebSearchBlock: React.FC<EnhancedWebSearchBlockProps> = ({
 	searchQuery,
 	baseLink,
+	browserModel,
 	content,
 	streamType,
 	approvalState,
@@ -100,6 +101,12 @@ export const EnhancedWebSearchBlock: React.FC<EnhancedWebSearchBlockProps> = ({
 						<a href={baseLink} target="_blank" rel="noopener noreferrer" className="text-primary">
 							{baseLink}
 						</a>
+					</p>
+				)}
+				{browserModel && (
+					<p>
+						<span className="font-semibold">Browser model:</span>{" "}
+						{browserModel === "fast" ? "Claude 3.5 Haiku" : "Claude 3.5 Sonnet"}
 					</p>
 				)}
 			</div>


### PR DESCRIPTION
## What
Depends on https://github.com/kodu-ai/webapp/pull/52

Added browser models for web search tool, I don't like the naming convention `smart/fast` but I felt it was at least semantically better than giving `claude-3.5-haiku/sonnet`

Always defaults to fast -> sonnet

#### TCs
![Screenshot 2024-10-31 at 8 56 37 PM](https://github.com/user-attachments/assets/1711aa15-4c50-4e39-aacb-03f2af625cbf)


![Screenshot 2024-10-31 at 7 57 41 PM](https://github.com/user-attachments/assets/65ff1cb2-75f9-40ce-827e-535e753e3330)
