### PR TITLE
Feature/diff creator

### DIFF
--- a/extension/src/agent/v1/prompts/tools.prompt.ts
+++ b/extension/src/agent/v1/prompts/tools.prompt.ts
@@ -45,18 +45,35 @@ Usage:
 </read_file>
 
 ## write_to_file
-Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. Always provide the full intended content of the file, without any truncation. This tool will automatically create any directories needed to write the file.
+Description: Request to write content to a file at the specified path. If the file exists, provide a unified diff (udiff) in the <udiff> parameter representing the changes to be made. If the file doesn't exist, provide the full intended content of the file in the 'content' parameter, without any truncation. This tool will automatically create any directories needed to write the file.
 Parameters:
 - path: (required) The path of the file to write to (relative to the current working directory ${cwd.toPosix()})
-- content: (required) The COMPLETE intended content to write to the file. ALWAYS provide the COMPLETE file content in your response, without any truncation. This is NON-NEGOTIABLE, as partial updates or placeholders are STRICTLY FORBIDDEN.
-Example of forbidden content: '// rest of code unchanged' | '// your implementation here' | '// code here ...' if you are writing code to a file, you must provide the complete code, no placeholders, no partial updates, you must write all the code!
+- content: (required when creating a new file) The COMPLETE intended content to write to the file. ALWAYS provide the COMPLETE file content in your response, without any truncation. This is NON-NEGOTIABLE, as partial updates or placeholders are STRICTLY FORBIDDEN.
+- udiff: (required when modifying an existing file) The unified diff representing the changes to be made to the existing file.
+
+Example of forbidden content: '// rest of code unchanged' | '// your implementation here' | '// code here ...' if you are writing code to a new file, you must provide the complete code, no placeholders, no partial updates, you must write all the code! In case it's an update to a file **MUST** include the <diff> parameter and not include the <content> parameter.
+###IMPORTANT##:
+When modifying an existing file, **NEVER** include the <content> parameter. Instead, provide the unified diff representing the changes to be made to the existing file.
+
 Usage:
+***Creating a new file:***
+
 <write_to_file>
 <path>File path here</path>
 <content>
 Complete file content here
 </content>
 </write_to_file>
+
+***Modifying an existing file:***
+
+<write_to_file>
+<path>File path here</path>
+<udiff>
+Unified diff here
+</udiff>
+</write_to_file>
+
 
 ## search_files
 Description: Request to perform a regex search across files in a specified directory, providing context-rich results. This tool searches for patterns or specific content across multiple files, displaying each match with encapsulating context.

--- a/extension/src/agent/v1/tools/schema/write_to_file.ts
+++ b/extension/src/agent/v1/tools/schema/write_to_file.ts
@@ -3,64 +3,93 @@ import { z } from "zod"
 
 /**
  * @tool write_to_file
- * @description Write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. Always provide the full intended content of the file, without any truncation. This tool will automatically create any directories needed to write the file.
+ * @description Write content to a file at the specified path. This tool has two modes of operation:
+ * 1. **Creating a New File**: Provide the full intended content using the `content` parameter. The file will be created if it does not exist.
+ * 2. **Modifying an Existing File**: Provide a unified diff (`udiff`) representing the changes to be made. This ensures minimal and precise modifications to existing files.
+ * If the file exists, use the `udiff` parameter to describe the changes. If the file doesn't exist, use the `content` parameter to create it with the provided content.
+ * Always provide the full content or accurate diffs. Never truncate content or use placeholders.
  * @schema
  * {
- *   path: string;    // The path of the file to write to.
- *   content: string; // The full content to write to the file.
+ *   path: string;        // The path of the file to write to.
+ *   content?: string;    // The complete content to write to the file when creating a new file.
+ *   udiff?: string;      // The unified diff representing changes to be made to an existing file.
  * }
- * @example
+ * @example (Creating a new file)
  * ```xml
  * <tool name="write_to_file">
  *   <path>/notes/todo.txt</path>
  *   <content>Buy groceries\nCall Alice</content>
  * </tool>
  * ```
- * @example
+ * @example (Modifying an existing file)
  * ```xml
  * <tool name="write_to_file">
  *   <path>/scripts/setup.sh</path>
- *   <content>#!/bin/bash\necho "Setting up environment"</content>
- * </tool>
- * ```
- * @example
- * ```xml
- * <tool name="write_to_file">
- *   <path>/data/output.json</path>
- *   <content>{"key": "value"}</content>
+ *   <udiff>
+ * --- a/scripts/setup.sh
+ * +++ b/scripts/setup.sh
+ * @@ -1,2 +1,2 @@
+ * -echo "Setting up environment"
+ * +echo "Initializing environment"
+ * </udiff>
  * </tool>
  * ```
  */
 const schema = z.object({
-	path: z.string().describe("The path of the file to write to (relative to the current working directory)."),
+	path: z
+	  .string()
+	  .describe("The path of the file to write to (relative to the current working directory)."),
 	content: z
-		.string()
-		.describe(
-			"The full content to write to the file this is critical any you should never truncate the content!. never write // the result of the file or any other variants of this for example // code goes here ... this will hurt the user and make you break the code."
-		),
-})
+	  .string()
+	  .describe(
+		"The full content to write to the file when creating a new file. Always provide the complete content without any truncation."
+	  )
+	  .optional(),
+	udiff: z
+	  .string()
+	  .describe(
+		"The unified diff representing the changes to be made to an existing file. This must be formatted correctly, including headers and context lines."
+	  )
+	  .optional(),
+  });
 
 const examples = [
-	`<tool name="write_to_file">
+  `<tool name="write_to_file">
   <path>/notes/todo.txt</path>
   <content>Buy groceries\nCall Alice</content>
 </tool>`,
 
-	`<tool name="write_to_file">
+  `<tool name="write_to_file">
   <path>/scripts/setup.sh</path>
-  <content>#!/bin/bash\necho "Setting up environment"</content>
+  <udiff>
+--- a/scripts/setup.sh
++++ b/scripts/setup.sh
+@@ -1,2 +1,2 @@
+-echo "Setting up environment"
++echo "Initializing environment"
+</udiff>
 </tool>`,
 
-	`<tool name="write_to_file">
-  <path>/data/output.json</path>
-  <content>{"key": "value"}</content>
+  `<tool name="write_to_file">
+  <path>/data/config.json</path>
+  <udiff>
+--- a/data/config.json
++++ b/data/config.json
+@@ -2,7 +2,7 @@
+{
+  "version": "1.0.0",
+- "debug": false,
++ "debug": true,
+  "features": ["feature1", "feature2"]
+}
+</udiff>
 </tool>`,
-]
+];
 
 export const writeToFileTool = {
-	schema: {
-		name: "write_to_file",
-		schema,
-	},
-	examples,
-}
+  schema: {
+    name: "write_to_file",
+    schema,
+  },
+  examples,
+};

--- a/extension/src/shared/new-tools.ts
+++ b/extension/src/shared/new-tools.ts
@@ -49,7 +49,8 @@ export type ReadFileTool = {
 export type WriteToFileTool = {
 	tool: "write_to_file"
 	path: string
-	content: string
+	content?: string
+	udiff?: string
 }
 
 export type AskFollowupQuestionTool = {

--- a/extension/webview-ui-vite/tailwind.config.js
+++ b/extension/webview-ui-vite/tailwind.config.js
@@ -1,4 +1,5 @@
 import plugin from "tailwindcss"
+import tailwindcssAnimate from "tailwindcss-animate"
 
 function parseColor(color) {
 	if (color.startsWith("#")) {
@@ -193,10 +194,10 @@ export default {
 				"accordion-up": "accordion-up 0.2s ease-out",
 				"border-beam": "border-beam calc(var(--duration)*1s) infinite linear",
 			},
-		},
+		}
 	},
 	plugins: [
-		require("tailwindcss-animate"),
+		tailwindcssAnimate,
 
 		plugin(function ({ addUtilities, theme }) {
 			const colors = theme("colors")


### PR DESCRIPTION
Changing the way we instruct the models how to build the writeToFileTool to include only diffs when working on files that already exist.
By doing so we reduce the amount of tokens the model responses back with, allowing for longer sessions with more accurate context.