### PR TITLE
fix code highlight styling

### DIFF
--- a/extension/webview-ui-vite/src/components/ChatRow/MarkdownRenderer.tsx
+++ b/extension/webview-ui-vite/src/components/ChatRow/MarkdownRenderer.tsx
@@ -164,31 +164,36 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ markdown, sy
 				h3: (props) => <h3 className="scroll-m-20 text-2xl font-semibold tracking-tight" {...props} />,
 				a: (props) => <a className="font-medium text-primary underline underline-offset-4" {...props} />,
 				blockquote: (props) => <blockquote className="mt-6 border-l-2 pl-6 italic" {...props} />,
-				// @ts-expect-error not typed
-				code: ({ node, inline, className, children, ...props }) => {
+				code: ({ node, inline, className, children, ...props }: any) => {
 					const match = /language-(\w+)/.exec(className || "")
-					return !inline && match ? (
-						// @ts-expect-error not typed
+					const language = match ? match[1] : undefined
+
+					if (!language) {
+						return (
+							<code
+								className="relative rounded bg-muted px-[0.3rem] py-[0.2rem] font-mono text-sm font-semibold"
+								{...props}>
+								{children}
+							</code>
+						)
+					}
+
+					// Style configuration for code blocks - removed border and adjusted padding
+					const codeBlockStyle = {
+						margin: "0",
+						padding: "0rem",
+						fontSize: "0.875rem",
+						background: "transparent" // Ensures no background highlight
+					}
+
+					return (
 						<SyntaxHighlighter
-							{...props}
-							children={String(children).replace(/\n$/, "")}
-							language={match[1]}
-							PreTag="div"
+							wrapLines
+							language={language}
 							style={syntaxHighlighterStyle}
-							customStyle={{
-								margin: "1rem 0",
-								padding: "1rem",
-								borderRadius: "0.375rem",
-								fontSize: "0.875rem",
-								lineHeight: "1.7142857",
-							}}
-						/>
-					) : (
-						<code
-							className="relative rounded bg-muted px-[0.3rem] py-[0.2rem] font-mono text-sm font-semibold"
-							{...props}>
-							{children}
-						</code>
+							customStyle={codeBlockStyle}>
+							{String(children).replace(/\n$/, "")}
+						</SyntaxHighlighter>
 					)
 				},
 				span: (props) => <span className="text-wrap whitespace-pre" {...props} />,


### PR DESCRIPTION
## Before 


<img width="271" alt="image" src="https://github.com/user-attachments/assets/ecda6c43-cfd0-4a3b-8861-aa426ab79a63">

## After

![CleanShot 2024-11-21 at 15 37 16@2x](https://github.com/user-attachments/assets/b6892e8f-2f5b-4921-9691-212cd04524b5)


Arguably still not really that good-looking but more compact 