### PR TITLE
Add a user-agent header for the custom provider

### DIFF
--- a/extension/src/api/providers/custom-provider.ts
+++ b/extension/src/api/providers/custom-provider.ts
@@ -11,6 +11,7 @@ import { customProviderSchema, ModelInfo } from "./types"
 import { PROVIDER_IDS } from "./constants"
 import { calculateApiCost } from "../api-utils"
 import { mistralConfig } from "./config/mistral"
+import { version } from "../../../package.json"
 import { z } from "zod"
 
 type ExtractCacheTokens = {
@@ -105,6 +106,9 @@ const providerToAISDKModel = (settings: ApiConstructorOptions, modelId: string) 
 				compatibility: "compatible",
 				baseURL: providerSettings.data.baseUrl,
 				name: providerSettings.data.modelId,
+				headers: {
+					"User-Agent": `Kodu/${version}`
+				}
 			}).languageModel(modelId)
 
 		default:


### PR DESCRIPTION
The custom provider is useful when you point kodu to a proxy. In that
case, it might be also useful for the proxy to know what kind of client
is it talking to it to differentiate between different coding
assistants.

This patch adds the User-Agent header set to Kodu/version.
