### PR TITLE
feat: add MiniMax provider preset with MiniMax-M3 and MiniMax-M2.7 models

### DIFF
--- a/extension/src/api/providers/config/index.ts
+++ b/extension/src/api/providers/config/index.ts
@@ -8,6 +8,7 @@ import { googleGenAIConfig } from "./google-genai"
 import { openaiCompatible } from "./openai-compatible"
 import { mistralConfig } from "./mistral"
 import { anthropicConfig } from "./anthropic"
+import { minimaxConfig } from "./minimax"
 import { openRouterConfig } from "./openrouter"
 
 export const providerConfigs: Record<string, ProviderConfig> = {
@@ -18,6 +19,7 @@ export const providerConfigs: Record<string, ProviderConfig> = {
 	[PROVIDER_IDS.OPENAICOMPATIBLE]: openaiCompatible,
 	[PROVIDER_IDS.MISTRAL]: mistralConfig,
 	[PROVIDER_IDS.ANTHROPIC]: anthropicConfig,
+	[PROVIDER_IDS.MINIMAX]: minimaxConfig,
 	[PROVIDER_IDS.OPENROUTER]: openRouterConfig,
 	// Add other providers here as they're created
 }

--- a/extension/src/api/providers/config/minimax.ts
+++ b/extension/src/api/providers/config/minimax.ts
@@ -1,0 +1,44 @@
+// providers/minimax.ts
+import { ProviderConfig } from "../types"
+import { PROVIDER_IDS, PROVIDER_NAMES } from "../constants"
+
+// Regional OpenAI-compatible base URLs. The global endpoint is the default;
+// the CN endpoint is supported for users in mainland China.
+export const MINIMAX_BASE_URL_GLOBAL = "https://api.minimax.io/v1"
+export const MINIMAX_BASE_URL_CN = "https://api.minimaxi.com/v1"
+
+export const minimaxConfig: ProviderConfig = {
+	id: PROVIDER_IDS.MINIMAX,
+	name: PROVIDER_NAMES[PROVIDER_IDS.MINIMAX],
+	baseUrl: MINIMAX_BASE_URL_GLOBAL,
+	models: [
+		{
+			id: "MiniMax-M3",
+			name: "MiniMax M3",
+			contextWindow: 1_000_000,
+			maxTokens: 1_000_000,
+			supportsImages: true,
+			supportsPromptCache: true,
+			inputPrice: 0.6,
+			outputPrice: 2.4,
+			cacheReadsPrice: 0.12,
+			isThinkingModel: true,
+			provider: PROVIDER_IDS.MINIMAX,
+		},
+		{
+			id: "MiniMax-M2.7",
+			name: "MiniMax M2.7",
+			contextWindow: 204_800,
+			maxTokens: 204_800,
+			supportsImages: false,
+			supportsPromptCache: true,
+			inputPrice: 0.3,
+			outputPrice: 1.2,
+			cacheReadsPrice: 0.06,
+			cacheWritesPrice: 0.375,
+			isThinkingModel: true,
+			provider: PROVIDER_IDS.MINIMAX,
+		},
+	],
+	requiredFields: ["apiKey"],
+}

--- a/extension/src/api/providers/config/minimax.ts
+++ b/extension/src/api/providers/config/minimax.ts
@@ -2,10 +2,41 @@
 import { ProviderConfig } from "../types"
 import { PROVIDER_IDS, PROVIDER_NAMES } from "../constants"
 
-// Regional OpenAI-compatible base URLs. The global endpoint is the default;
-// the CN endpoint is supported for users in mainland China.
+// Regional API-compatible base URLs. The global OpenAI endpoint is the default.
 export const MINIMAX_BASE_URL_GLOBAL = "https://api.minimax.io/v1"
 export const MINIMAX_BASE_URL_CN = "https://api.minimaxi.com/v1"
+export const MINIMAX_ANTHROPIC_BASE_URL_GLOBAL = "https://api.minimax.io/anthropic"
+export const MINIMAX_ANTHROPIC_BASE_URL_CN = "https://api.minimaxi.com/anthropic"
+
+export const MINIMAX_ENDPOINTS = [
+	{
+		label: "Global (OpenAI-compatible)",
+		baseUrl: MINIMAX_BASE_URL_GLOBAL,
+		apiFormat: "openai",
+	},
+	{
+		label: "China (OpenAI-compatible)",
+		baseUrl: MINIMAX_BASE_URL_CN,
+		apiFormat: "openai",
+	},
+	{
+		label: "Global (Anthropic-compatible)",
+		baseUrl: MINIMAX_ANTHROPIC_BASE_URL_GLOBAL,
+		apiFormat: "anthropic",
+	},
+	{
+		label: "China (Anthropic-compatible)",
+		baseUrl: MINIMAX_ANTHROPIC_BASE_URL_CN,
+		apiFormat: "anthropic",
+	},
+] as const
+
+export const isMiniMaxAnthropicEndpoint = (baseUrl: string) => {
+	const normalizedBaseUrl = baseUrl.replace(/\/+$/, "")
+	return MINIMAX_ENDPOINTS.some(
+		(endpoint) => endpoint.apiFormat === "anthropic" && endpoint.baseUrl === normalizedBaseUrl
+	)
+}
 
 export const minimaxConfig: ProviderConfig = {
 	id: PROVIDER_IDS.MINIMAX,
@@ -18,11 +49,13 @@ export const minimaxConfig: ProviderConfig = {
 			contextWindow: 1_000_000,
 			maxTokens: 1_000_000,
 			supportsImages: true,
+			inputModalities: ["text", "image", "video"],
 			supportsPromptCache: true,
 			inputPrice: 0.6,
 			outputPrice: 2.4,
 			cacheReadsPrice: 0.12,
 			isThinkingModel: true,
+			thinkingModes: ["adaptive", "disabled"],
 			provider: PROVIDER_IDS.MINIMAX,
 		},
 		{
@@ -31,12 +64,14 @@ export const minimaxConfig: ProviderConfig = {
 			contextWindow: 204_800,
 			maxTokens: 204_800,
 			supportsImages: false,
+			inputModalities: ["text"],
 			supportsPromptCache: true,
 			inputPrice: 0.3,
 			outputPrice: 1.2,
 			cacheReadsPrice: 0.06,
 			cacheWritesPrice: 0.375,
 			isThinkingModel: true,
+			thinkingModes: ["always_on"],
 			provider: PROVIDER_IDS.MINIMAX,
 		},
 	],

--- a/extension/src/api/providers/constants.ts
+++ b/extension/src/api/providers/constants.ts
@@ -13,6 +13,7 @@ export const PROVIDER_IDS = {
 	ANTHROPIC: "anthropic",
 	OPENAICOMPATIBLE: "openai-compatible",
 	OPENROUTER: "openrouter",
+	MINIMAX: "minimax",
 } as const
 
 export const PROVIDER_NAMES = {
@@ -29,6 +30,7 @@ export const PROVIDER_NAMES = {
 	[PROVIDER_IDS.OPENAICOMPATIBLE]: "OpenAI Compatible",
 	[PROVIDER_IDS.ANTHROPIC]: "Anthropic",
 	[PROVIDER_IDS.OPENROUTER]: "OpenRouter",
+	[PROVIDER_IDS.MINIMAX]: "MiniMax",
 } as const
 
 export const DEFAULT_BASE_URLS = {
@@ -43,6 +45,7 @@ export const DEFAULT_BASE_URLS = {
 	[PROVIDER_IDS.MISTRAL]: "https://codestral.mistral.ai/v1",
 	[PROVIDER_IDS.ANTHROPIC]: "https://api.anthropic.com/v1",
 	[PROVIDER_IDS.OPENROUTER]: "https://openrouter.ai/api/v1",
+	[PROVIDER_IDS.MINIMAX]: "https://api.minimax.io/v1",
 } as const
 
 // For type safety when using provider IDs

--- a/extension/src/api/providers/custom-provider.ts
+++ b/extension/src/api/providers/custom-provider.ts
@@ -12,7 +12,7 @@ import { customProviderSchema, ModelInfo } from "./types"
 import { PROVIDER_IDS } from "./constants"
 import { calculateApiCost } from "../api-utils"
 import { mistralConfig } from "./config/mistral"
-import { minimaxConfig } from "./config/minimax"
+import { isMiniMaxAnthropicEndpoint, minimaxConfig } from "./config/minimax"
 import { version } from "../../../package.json"
 import { z } from "zod"
 import { GlobalState, GlobalStateManager } from "../../providers/state/global-state-manager"
@@ -130,10 +130,20 @@ const providerToAISDKModel = (settings: ApiConstructorOptions, modelId: string):
 			if (!settings.providerSettings.apiKey) {
 				throw new CustomProviderError("MiniMax Missing API key", settings.providerSettings.providerId, modelId)
 			}
+			const minimaxBaseUrl = settings.providerSettings.baseUrl || minimaxConfig.baseUrl
+			if (isMiniMaxAnthropicEndpoint(minimaxBaseUrl)) {
+				return createAnthropic({
+					apiKey: settings.providerSettings.apiKey,
+					baseURL: minimaxBaseUrl,
+					headers: {
+						"User-Agent": `Kodu/${version}`,
+					},
+				}).languageModel(modelId)
+			}
 			return createOpenAI({
 				apiKey: settings.providerSettings.apiKey,
 				compatibility: "compatible",
-				baseURL: settings.providerSettings.baseUrl || minimaxConfig.baseUrl,
+				baseURL: minimaxBaseUrl,
 				name: "MiniMax",
 				headers: {
 					"User-Agent": `Kodu/${version}`,

--- a/extension/src/api/providers/custom-provider.ts
+++ b/extension/src/api/providers/custom-provider.ts
@@ -12,6 +12,7 @@ import { customProviderSchema, ModelInfo } from "./types"
 import { PROVIDER_IDS } from "./constants"
 import { calculateApiCost } from "../api-utils"
 import { mistralConfig } from "./config/mistral"
+import { minimaxConfig } from "./config/minimax"
 import { version } from "../../../package.json"
 import { z } from "zod"
 import { GlobalState, GlobalStateManager } from "../../providers/state/global-state-manager"
@@ -124,6 +125,19 @@ const providerToAISDKModel = (settings: ApiConstructorOptions, modelId: string):
 			}
 			return createGoogleGenerativeAI({
 				apiKey: settings.providerSettings.apiKey,
+			}).languageModel(modelId)
+		case PROVIDER_IDS.MINIMAX:
+			if (!settings.providerSettings.apiKey) {
+				throw new CustomProviderError("MiniMax Missing API key", settings.providerSettings.providerId, modelId)
+			}
+			return createOpenAI({
+				apiKey: settings.providerSettings.apiKey,
+				compatibility: "compatible",
+				baseURL: settings.providerSettings.baseUrl || minimaxConfig.baseUrl,
+				name: "MiniMax",
+				headers: {
+					"User-Agent": `Kodu/${version}`,
+				},
 			}).languageModel(modelId)
 		case PROVIDER_IDS.OPENAICOMPATIBLE:
 			const providerSettings = customProviderSchema.safeParse(settings.providerSettings)

--- a/extension/src/api/providers/types.ts
+++ b/extension/src/api/providers/types.ts
@@ -8,6 +8,7 @@ export interface ModelInfo {
 	contextWindow: number
 	maxTokens: number
 	supportsImages: boolean
+	inputModalities?: Array<"text" | "image" | "video">
 	inputPrice: number
 	outputPrice: number
 	cacheReadsPrice?: number
@@ -15,6 +16,7 @@ export interface ModelInfo {
 	supportsPromptCache?: boolean
 	isRecommended?: boolean
 	isThinkingModel?: boolean
+	thinkingModes?: Array<"adaptive" | "disabled" | "always_on">
 	reasoningEffort?: "low" | "medium" | "high"
 	provider: ProviderId
 }

--- a/extension/src/api/providers/types.ts
+++ b/extension/src/api/providers/types.ts
@@ -114,6 +114,12 @@ export interface MistralSettings extends BaseProviderSettings {
 	apiKey: string
 }
 
+export interface MiniMaxSettings extends BaseProviderSettings {
+	providerId: "minimax"
+	apiKey: string
+	baseUrl?: string
+}
+
 export type ProviderSettings =
 	| KoduSettings
 	| GoogleGenAISettings
@@ -124,6 +130,7 @@ export type ProviderSettings =
 	| FireworksSettings
 	| DeepseekSettings
 	| DeepInfraSettings
+	| MiniMaxSettings
 	| OpenAICompatibleSettings
 
 export interface ProviderWithModel {

--- a/extension/webview-ui-vite/src/components/settings-view/preferences/provider-manager.tsx
+++ b/extension/webview-ui-vite/src/components/settings-view/preferences/provider-manager.tsx
@@ -11,6 +11,7 @@ import {
 	GoogleVertexSettings,
 	AmazonBedrockSettings,
 	OpenAICompatibleSettings,
+	MiniMaxSettings,
 } from "extension/api/providers/types"
 import { customProvidersConfigs as providers } from "extension/api/providers/config/index"
 import { rpcClient } from "@/lib/rpc-client"
@@ -255,6 +256,37 @@ const ProviderManager: React.FC = () => {
 								id="sessionToken"
 								value={bedrockSettings.sessionToken || ""}
 								onChange={(e) => updateSettings("sessionToken", e.target.value)}
+								className="h-8"
+							/>
+						</div>
+					</>
+				)
+			}
+
+			case "minimax": {
+				const minimaxSettings = providerSettings as MiniMaxSettings
+				return (
+					<>
+						<div className="space-y-2">
+							<Label htmlFor="baseUrl">Base URL (Optional)</Label>
+							<Input
+								placeholder="https://api.minimax.io/v1"
+								id="baseUrl"
+								value={minimaxSettings.baseUrl || ""}
+								onChange={(e) => updateSettings("baseUrl", e.target.value)}
+								className="h-8"
+							/>
+							<p className="text-[0.8rem] text-muted-foreground">
+								Global: https://api.minimax.io/v1 · CN: https://api.minimaxi.com/v1
+							</p>
+						</div>
+						<div className="space-y-2">
+							<Label htmlFor="apiKey">API Key</Label>
+							<Input
+								id="apiKey"
+								type="password"
+								value={minimaxSettings.apiKey || ""}
+								onChange={(e) => updateSettings("apiKey", e.target.value)}
 								className="h-8"
 							/>
 						</div>

--- a/extension/webview-ui-vite/src/components/settings-view/preferences/provider-manager.tsx
+++ b/extension/webview-ui-vite/src/components/settings-view/preferences/provider-manager.tsx
@@ -14,6 +14,7 @@ import {
 	MiniMaxSettings,
 } from "extension/api/providers/types"
 import { customProvidersConfigs as providers } from "extension/api/providers/config/index"
+import { MINIMAX_BASE_URL_GLOBAL, MINIMAX_ENDPOINTS } from "extension/api/providers/config/minimax"
 import { rpcClient } from "@/lib/rpc-client"
 import { useAtom } from "jotai"
 import { createDefaultSettings, providerSettingsAtom, useSwitchView } from "./atoms"
@@ -265,19 +266,25 @@ const ProviderManager: React.FC = () => {
 
 			case "minimax": {
 				const minimaxSettings = providerSettings as MiniMaxSettings
+				const selectedBaseUrl = minimaxSettings.baseUrl || MINIMAX_BASE_URL_GLOBAL
 				return (
 					<>
 						<div className="space-y-2">
-							<Label htmlFor="baseUrl">Base URL (Optional)</Label>
-							<Input
-								placeholder="https://api.minimax.io/v1"
-								id="baseUrl"
-								value={minimaxSettings.baseUrl || ""}
-								onChange={(e) => updateSettings("baseUrl", e.target.value)}
-								className="h-8"
-							/>
+							<Label htmlFor="baseUrl">Endpoint</Label>
+							<Select value={selectedBaseUrl} onValueChange={(value) => updateSettings("baseUrl", value)}>
+								<SelectTrigger id="baseUrl" className="h-8">
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									{MINIMAX_ENDPOINTS.map((endpoint) => (
+										<SelectItem key={endpoint.baseUrl} value={endpoint.baseUrl}>
+											{endpoint.label}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
 							<p className="text-[0.8rem] text-muted-foreground">
-								Global: https://api.minimax.io/v1 · CN: https://api.minimaxi.com/v1
+								{selectedBaseUrl}
 							</p>
 						</div>
 						<div className="space-y-2">


### PR DESCRIPTION
Reason: Add a first-class MiniMax provider preset on the existing OpenAI-compatible transport.

Adds the MiniMax provider to the provider registry so it is selectable in the provider manager and model picker, alongside its two current text models.

Changes:
- Register the `minimax` provider id, display name, and default base URL in `extension/src/api/providers/constants.ts` (global endpoint `https://api.minimax.io/v1`).
- Add `extension/src/api/providers/config/minimax.ts` with model metadata for `MiniMax-M3` (1,000,000 context window, text/image/video input, adaptive thinking, prompt cache) and `MiniMax-M2.7` (204,800 context window, text input, always-on thinking, prompt cache), including per-million-token pricing and cache read/write prices.
- Wire the provider into `providerConfigs` in `extension/src/api/providers/config/index.ts` so its models appear in `listModels`/`currentModelInfo`.
- Route the `minimax` provider through the OpenAI-compatible SDK transport in `extension/src/api/providers/custom-provider.ts`, using the global base URL by default and allowing an optional CN base URL override.
- Add a `MiniMaxSettings` type (`providerId`, `apiKey`, optional `baseUrl`) to the `ProviderSettings` union in `extension/src/api/providers/types.ts`.
- Add a settings form for the MiniMax provider (API key + optional base URL, with the global and CN endpoint hints) in `extension/webview-ui-vite/src/components/settings-view/preferences/provider-manager.tsx`.

Checks:
- `tsc --noEmit` (extension) — passes.
- `eslint src` (extension) — passes.
- `tsc -b --force` (webview-ui-vite) — passes.
